### PR TITLE
Revert "Ins 12"

### DIFF
--- a/inetsense/inetsense-probe/inetsense-probe-logic/pom.xml
+++ b/inetsense/inetsense-probe/inetsense-probe-logic/pom.xml
@@ -10,15 +10,7 @@
         <artifactId>inetsense-probe</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
-    
-    <dependencies>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
-        </dependency>
-    </dependencies>
-    
+
     <build>
         <plugins>
             <plugin>

--- a/inetsense/inetsense-probe/inetsense-probe-logic/src/main/java/hu/elte/inetsense/probe/InetsenseProbe.java
+++ b/inetsense/inetsense-probe/inetsense-probe-logic/src/main/java/hu/elte/inetsense/probe/InetsenseProbe.java
@@ -1,15 +1,19 @@
 
 package hu.elte.inetsense.probe;
 
-import org.apache.log4j.Logger;
 import hu.elte.inetsense.probe.speedtester.SpeedTester;
-import hu.elte.inetsense.probe.uploader.*;
+import hu.elte.inetsense.probe.uploader.ConfigLoader;
+import hu.elte.inetsense.probe.uploader.DataUploader;
 
-
+/**
+ *
+ * Entry point.
+ *
+ * @author Adam Kecskes
+ */
 public class InetsenseProbe {
 
-    public static Logger log = Logger.getLogger(InetsenseProbe.class.getName());
-    
+
     public static void main(String[] args) {
 
         ConfigLoader cf = null;
@@ -25,9 +29,7 @@ public class InetsenseProbe {
         if(cf == null) {
             cf = new ConfigLoader();
         }
-        
-        InetsenseProbe.log.info("Config loaded");
-        
+
         DataUploader du = new DataUploader(cf.get("host")+":"+cf.get("port")+"/message-endpoint" ,cf.get("probe-id"));
         SpeedTester se = new SpeedTester(
           du,

--- a/inetsense/inetsense-probe/inetsense-probe-logic/src/main/java/hu/elte/inetsense/probe/uploader/ConfigLoader.java
+++ b/inetsense/inetsense-probe/inetsense-probe-logic/src/main/java/hu/elte/inetsense/probe/uploader/ConfigLoader.java
@@ -1,7 +1,6 @@
 
 package hu.elte.inetsense.probe.uploader;
 
-import hu.elte.inetsense.probe.InetsenseProbe;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
@@ -22,12 +21,12 @@ public class ConfigLoader {
     
     public ConfigLoader(String path) {
         
-        InetsenseProbe.log.info("Loading ini file from: "+path);
+        System.out.println("Loading ini file from: "+path);
         
         try {
             loadIni(new FileInputStream(path));
         } catch (FileNotFoundException ex) {
-            InetsenseProbe.log.error("File not found, loadign default ini");
+            System.out.println("File not found, loadign default ini");
             loadIni(getDefaultIniStream());
         }
     }

--- a/inetsense/inetsense-probe/inetsense-probe-logic/src/main/java/hu/elte/inetsense/probe/uploader/DataUploader.java
+++ b/inetsense/inetsense-probe/inetsense-probe-logic/src/main/java/hu/elte/inetsense/probe/uploader/DataUploader.java
@@ -1,6 +1,5 @@
 package hu.elte.inetsense.probe.uploader;
 
-import hu.elte.inetsense.probe.InetsenseProbe;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -8,6 +7,10 @@ import java.io.*;
 import java.net.*;
 import java.nio.charset.StandardCharsets;
 
+/**
+ *
+ * @author Adam Kecskes
+ */
 public class DataUploader{
     
     private String probe_id;
@@ -23,6 +26,7 @@ public class DataUploader{
     public void addMeasurement(Measurement me) {
         
         this.measurements.add(me);
+        System.out.println(me.getDownload());
         
         this.flush();
         
@@ -41,6 +45,8 @@ public class DataUploader{
         }
         
         data += "]}";
+        
+        System.out.println(data);
         
         try {
             URL url = new URL(server_location);
@@ -63,7 +69,7 @@ public class DataUploader{
             wr.flush();
             wr.close();
             
-            InetsenseProbe.log.info("DATA sent! Response code: "+conn.getResponseCode());
+            System.out.println("DATA sent! Response code: "+conn.getResponseCode());
             
             this.measurements.clear();
             
@@ -71,7 +77,7 @@ public class DataUploader{
         
         } catch(Exception ex) {
             // print error, try again later
-            InetsenseProbe.log.error(ex.getMessage());
+            System.out.println(ex.getMessage());
         }
         
     }

--- a/inetsense/inetsense-probe/inetsense-probe-logic/src/main/java/hu/elte/inetsense/probe/uploader/Measurement.java
+++ b/inetsense/inetsense-probe/inetsense-probe-logic/src/main/java/hu/elte/inetsense/probe/uploader/Measurement.java
@@ -1,8 +1,16 @@
-
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
 package hu.elte.inetsense.probe.uploader;
 
 import java.text.SimpleDateFormat;
 
+/**
+ *
+ * @author Adam
+ */
 public class Measurement {
     
     private long timestamp;

--- a/inetsense/inetsense-probe/inetsense-probe-logic/src/main/resources/log4j.properties
+++ b/inetsense/inetsense-probe/inetsense-probe-logic/src/main/resources/log4j.properties
@@ -1,5 +1,0 @@
-log4j.rootLogger=DEBUG,console
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-
-# Define the layout for X appender
-log4j.appender.console.layout=org.apache.log4j.PatternLayout


### PR DESCRIPTION
Reverts zdtorok/inetsense#42

> On August 5, 2015 the Logging Services Project Management Committee announced that Log4j 1.x had reached end of life. For complete text of the announcement please see the Apache Blog. Users of Log4j 1 are recommended to upgrade to Apache Log4j 2.

- please update a legfrissebb log4j verzióra (2.5).
- minden osztály saját loggert használjon.